### PR TITLE
Update REST API PayPal SDK from 1.3 to 1.11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "illuminate/support": "~5.0",
         "ext-curl": "*",
         "ext-json": "*",
-        "paypal/rest-api-sdk-php": "1.3.0"
+        "paypal/rest-api-sdk-php": "1.11.0"
     },
     "require-dev":{
         "phpspec/phpspec": "~2.0"


### PR DESCRIPTION
Hi, please update the paypal/rest-api-sdk-php in your composer.json from 1.3.0 to 1.11.0 to prevent SSL issues over HTTPS :)