### PR TITLE
Add support laravel 5.4

### DIFF
--- a/src/Anouar/Paypalpayment/PaypalpaymentServiceProvider.php
+++ b/src/Anouar/Paypalpayment/PaypalpaymentServiceProvider.php
@@ -42,7 +42,7 @@ class PaypalpaymentServiceProvider extends ServiceProvider {
      */
     public function register()
     {
-        $this->app['paypalpayment'] = $this->app->share(function($app)
+        $this->app->singleton('paypalpayment', function($app)
         {
             return new PaypalPayment();
         });


### PR DESCRIPTION
Seems in laravel 5.4 method share don't more exist. Maybe using singleton method will be fine for versions 5.* for compatible?