### PR TITLE
Update using sdk from paypal

### DIFF
--- a/src/Anouar/Paypalpayment/PaypalPayment.php
+++ b/src/Anouar/Paypalpayment/PaypalPayment.php
@@ -245,7 +245,7 @@ class PaypalPayment{
      */
     public  static function OAuthTokenCredential($ClientId = null, $ClientSecret=null)
     {
-        //define("PP_CONFIG_PATH", __DIR__);
+        define("PP_CONFIG_PATH", __DIR__);
 
         if(isset($ClientId) && isset($ClientSecret)) {
           return new OAuthTokenCredential($ClientId, $ClientSecret);

--- a/src/Anouar/Paypalpayment/PaypalPayment.php
+++ b/src/Anouar/Paypalpayment/PaypalPayment.php
@@ -25,7 +25,7 @@ use PayPal\Api\Sale;
 use PayPal\Api\ShippingAddress;
 use PayPal\Api\Transaction;
 use PayPal\Api\Transactions;
-use PayPal\Core\PPConfigManager;
+use PayPal\Core\PayPalConfigManager;
 use PayPal\Rest\ApiContext;
 use PayPal\Auth\OAuthTokenCredential;
 
@@ -251,7 +251,7 @@ class PaypalPayment{
           return new OAuthTokenCredential($ClientId, $ClientSecret);
         }
 
-        $configManager  = PPConfigManager::getInstance();
+        $configManager  = PayPalConfigManager::getInstance();
         // $cred is used by samples that include this bootstrap file
         // This piece of code simply demonstrates how you can
         // dynamically pass in a client id/secret instead of using

--- a/src/Anouar/Paypalpayment/sdk_config.ini
+++ b/src/Anouar/Paypalpayment/sdk_config.ini
@@ -13,9 +13,8 @@ http.Retry = 1
 
 ;Service Configuration
 [Service]
-;service.EndPoint="https://api.sandbox.paypal.com"
-;Uncomment this line for integrating with the live endpoint
-;service.EndPoint="https://api.paypal.com"
+#You must set the mode property to either 'sandbox' or 'live'.
+;mode='sandbox'
 
 
 ;Logging Information


### PR DESCRIPTION
I wanted to use Paypalpayment::OAuthTokenCredential, but there was some errors, with depends from paypal-sdk version. Maybe should update package to current version sdk or use or use the early version?